### PR TITLE
Implement stable URLs for constructions

### DIFF
--- a/static/js/constructicon.js
+++ b/static/js/constructicon.js
@@ -300,6 +300,8 @@ var app = new Vue({
         all_data_loaded: function(new_, old_) {
             // to make sure that when we load the page first time, we see all results
             this.search();
+            this.set_record_from_fragment();
+            this.track_fragment();
         },
         search_string: function(new_, old_) {
             this.search_debounced();
@@ -327,6 +329,9 @@ var app = new Vue({
         },
         semantic_types_selected: function(new_, old_) {
             this.advanced_search_debounced();
+        },
+        current_record_number: function(new_, old_) {
+            this.set_fragment_from_record(new_);
         },
     },
     methods: {
@@ -408,6 +413,20 @@ var app = new Vue({
             let selected = random_selection(records_with_this_level, 5);
             selected.sort((a, b) => a - b);
             this.record_numbers_matching_search = selected;
-        }
+        },
+        set_record_from_fragment: function() {
+            let hash = window.location.hash.slice(1);
+            this.current_record_number = this.record_numbers.includes(hash) ? hash : null;
+        },
+        track_fragment: function() {
+            window.addEventListener('hashchange', () => {
+                this.set_record_from_fragment();
+            });
+        },
+        set_fragment_from_record: function (record_number) {
+            if (record_number && record_number !== window.location.hash.slice(1)) {
+                window.history.pushState(null, '', '#' + record_number);
+            }
+        },
     }
 })

--- a/static/js/constructicon.js
+++ b/static/js/constructicon.js
@@ -415,8 +415,8 @@ var app = new Vue({
             this.record_numbers_matching_search = selected;
         },
         set_record_from_fragment: function() {
-            let hash = window.location.hash.slice(1);
-            this.current_record_number = this.record_numbers.includes(hash) ? hash : null;
+            let fragment = window.location.hash.slice(1);
+            this.current_record_number = this.record_numbers.includes(fragment) ? fragment : null;
         },
         track_fragment: function() {
             window.addEventListener('hashchange', () => {


### PR DESCRIPTION
Hello there! I came across your website while researching Laura Janda's work on Russian verbs and found it very nice!

I'm an open source contributor and I really liked your university's enthusiasm in regards to open source. In return for your contribution to open source linguistics, I would want to suggest a feature for your website: stable URLs for constructions.

Rationale: 
* Users will get the ability to link specific constructions.
* They will also be able to navigate back and forward between constructions they viewed.

Here's a demonstration:

https://github.com/constructicon/russian/assets/33615628/0963ccdb-faa2-4665-9a1e-6d9b750905b6

I have tested the patch on my machine in Chrome and Firefox. It works on all pages, including /advanced-search/ and /daily/.

It does the following:
1. Sets the construction in the select to the one specified in the URL fragment (#number), both at page load and when the user changes it. If there is no construction with that number in the record list, it clears the selection.
2. Sets the URL fragment when the user selects a construction in the select.

I would also suggest changing the page title together with the URL fragment so that the names of the constructions are evident to the user when they navigate them, but that would be trickier.
