### PR TITLE
Fix JavaScript error when selecting certain constructions

### DIFF
--- a/static/js/constructicon.js
+++ b/static/js/constructicon.js
@@ -392,7 +392,7 @@ var app = new Vue({
         },
         annotate: function(text) {
             // renders words that come right after [...] as subscript with color
-            let matches = text.match(/(?<=\])[A-Za-z]+/g);
+            let matches = text.match(/(?<=\])[A-Za-z]+/g) || [];
             for (let substring of matches) {
                 text = text.replace(substring, '<sub><span style="color: #db2f6d">' + substring + '</span></sub>');
             }


### PR DESCRIPTION
There is a bug: you can't select certain constructions if their definition contains no text that matches the regular expression in the annotate() method. The error "TypeError: matches is not iterable" is thrown.

Steps to reproduce:
1. Go to https://constructicon.github.io/russian/
2. Try to select construction 35
3. Open the JavaScript console and witness the error

This is because a semantic role is missed after "[objekt, deltaker, tidspunkt, sted, handlemåte eller forklaring]" in the definition, see https://github.com/constructicon/russian-data/blob/main/data/0035.yml.

This obviously needs to be fixed in the source, which, to my understanding, is private, but in any case, the code should be guarded from user mistakes like this. In this commit, the issue is resolved by setting the variable to an empty array if there is no matches.